### PR TITLE
Strict compiler warnings

### DIFF
--- a/combinations.h
+++ b/combinations.h
@@ -538,8 +538,8 @@ template <class BidirIter>
 std::uintmax_t
 count_each_permutation(BidirIter first, BidirIter mid, BidirIter last)
 {
-    return count_each_permutation<std::uintmax_t>
-                          (std::distance(first, mid), std::distance(mid, last));
+    return count_each_permutation(static_cast<std::uintmax_t>(std::distance(first, mid)),
+                                  static_cast<std::uintmax_t>(std::distance(mid, last)));
 }
 
 namespace detail

--- a/combinations.h
+++ b/combinations.h
@@ -910,7 +910,6 @@ public:
     {
         if (s_ == 1)
             return f_(first, last);
-        typedef typename std::iterator_traits<BidirIter>::difference_type D;
         typedef bound_range<Function, BidirIter> BoundFunc;
         BoundFunc f(f_, first, last);
         BidirIter n = std::next(first);

--- a/combinations.h
+++ b/combinations.h
@@ -443,7 +443,7 @@ typename std::enable_if
     std::is_unsigned<Int>::value,
     void
 >::type
-check_non_negative(Int d1, Int d2)
+check_non_negative(Int, Int)
 {
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,10 +9,10 @@
 // print out a range separated by commas,
 //    return number of values printed.
 template <class It>
-unsigned
+size_t
 display(It begin, It end)
 {
-    unsigned r = 0;
+    size_t r = 0;
     if (begin != end)
     {
         std::cout << *begin;
@@ -29,10 +29,10 @@ display(It begin, It end)
 // functor called for each permutation
 class f
 {
-    unsigned len;
+    size_t len;
     std::uint64_t count;
 public:
-    explicit f(unsigned l) : len(l), count(0) {}
+    explicit f(size_t l) : len(l), count(0) {}
 
     template <class It>
         bool operator()(It first, It last)  // called for each permutation
@@ -41,7 +41,7 @@ public:
             ++count;
             // print out [first, mid) surrounded with [ ... ]
             std::cout << "[ ";
-            unsigned r = display(first, last);
+            size_t r = display(first, last);
             // If [mid, last) is not empty, then print it out too
             //     prefixed by " | "
             if (r < len)
@@ -67,10 +67,10 @@ int main()
                                                v.end(),
                                                f(v.size()));
     // print out "---" to the correct length for the above output
-    unsigned e = 3 * r + 2;
+    size_t e = 3 * r + 2;
     if (r < v.size())
         e += 1 + 3 * (v.size() - r);
-    for (unsigned i = 0; i < e; ++i)
+    for (size_t i = 0; i < e; ++i)
         std::cout << '-';
     // print out the permuted vector to show that it has the original order
     std::cout << "\n[ ";
@@ -83,3 +83,4 @@ int main()
     std::cout << "Found " << count << " permutations of " << v.size()
               << " objects taken " << r << " at a time.\n";
 }
+


### PR DESCRIPTION
I tend to compile with the following flags:

	--std=c++2a \
	-Werror \
	-Wall \
	-Wextra \
	-Wconversion \
	-Wsign-conversion -Wsign-promo \
	-Wnull-dereference \
	-fmax-errors=4 \
	-fno-strict-overflow \
	-fno-delete-null-pointer-checks \
	-Wshadow-compatible-local

With these warnings, building the main.cpp example failed with a number of warnings.  This PR resolves the warnings for me, but I'm not entirely sure that the static_cast<> choice is optimal.

Anyway, passing this along in case it is useful.

Thanks for your continued efforts in the C++ community!
